### PR TITLE
#39083 First pass at getting progress to display in panel.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -183,7 +183,22 @@ class AdobeEngine(sgtk.platform.Engine):
         :returns: the created widget_class instance
         """
         # TODO: ensure dialog is shown above CC
-        super(AdobeEngine, self).show_dialog(title, bundle, widget_class, *args, **kwargs)
+        if not self.has_ui:
+            self.log_error("Sorry, this environment does not support UI display! Cannot show "
+                           "the requested window '%s'." % title)
+            return None
+
+        # create the dialog:
+        dialog, widget = self._create_dialog_with_widget(title, bundle, widget_class, *args, **kwargs)
+
+        # show the dialog
+        dialog.show()
+
+        # raise the dialog to make sure it shows above CC product
+        dialog.raise_()
+
+        # lastly, return the instantiated widget
+        return widget
 
     def show_modal(self, title, bundle, widget_class, *args, **kwargs):
         """

--- a/extensions/basic/css/style.css
+++ b/extensions/basic/css/style.css
@@ -27,3 +27,24 @@ body {
     text-decoration: none;
     display: inline-block;
 }
+
+
+#sg_progress {
+    position: relative;
+    width: 100%;
+    height: 40px;
+}
+
+#sg_progress_label {
+    text-align: left;
+    line-height: 30px;
+    color: white;
+}
+
+#sg_progress_bar {
+    position: absolute;
+    width: 0%;
+    height: 10px;
+    background-color: dodgerblue;
+}
+

--- a/extensions/basic/html/panel.html
+++ b/extensions/basic/html/panel.html
@@ -47,6 +47,13 @@ are reserved by Shotgun Software Inc.
     <!-- TODO: style so that the footer is always at the bottom -->
     <br><br>
 
+    <!-- progress bar for startup -->
+    <div id="sg_progress" style="display:none;">
+      <div id="sg_progress_label"></div>
+      <div id="sg_progress_bar">
+      </div>
+    </div>
+
     <!-- footer -->
     <div id="sg_panel_footer">
     </div>

--- a/extensions/basic/js/shotgun/constants.js
+++ b/extensions/basic/js/shotgun/constants.js
@@ -45,3 +45,13 @@ sg_constants.product_info = {
 
 };
 
+// This is simply a lookup of panel div ids. The keys of this should never
+// change.
+sg_constants.panel_div_ids = {
+    contents: "sg_panel_contents",
+    footer: "sg_panel_footer",
+    header: "sg_panel_header",
+    progress: "sg_progress",
+    progress_bar: "sg_progress_bar",
+    progress_label: "sg_progress_label"
+};


### PR DESCRIPTION
Intercepts custom stdout messages from bootstrap since this all happens before the socket io stuff is ready. It feels a little dirty, but works. Curious what you think.

![out](https://cloud.githubusercontent.com/assets/2604646/20495181/ff54a774-afed-11e6-88eb-b9c4d615f4e1.gif)
