### PR TITLE
#40651: Now sets the active document's context on engine startup.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -195,12 +195,12 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
                 doc_path = self.adobe.app.activeDocument.fullName.fsName
                 if doc_path != self._ACTIVE_DOCUMENT_PATH:
                     # This is admittedly questionable. Setting the current
-                    # is a public function, but we're jumping the gun here,
-                    # because this is typically set after the engine init
-                    # process is complete. We're not done, though, and we
+                    # engine is a public function, but we're jumping the gun
+                    # here, because this is typically set after the engine init
+                    # process is completed. We're not done, though, and we
                     # have detected a situation where we need to change our
                     # context to match that of the DCC's current document,
-                    # and so we need to make sure that Core knows that we
+                    # and so we need to make sure that core knows that we
                     # are the current engine.
                     sgtk.platform.engine.set_current_engine(self)
                     self._handle_active_document_change(doc_path)

--- a/engine.py
+++ b/engine.py
@@ -61,6 +61,8 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
     _PROXY_WIN_HWND = None
     _HEARTBEAT_DISABLED = False
     _PROJECT_CONTEXT = None
+    _ACTIVE_DOCUMENT_PATH = None
+    _SEND_STATE_DISABLED = False
 
     ############################################################################
     # context changing
@@ -180,6 +182,30 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
                 pass
 
         self.__setup_connection_timer()
+
+        # This will ensure that we're in the correct context. If it fails, then
+        # it's most likely just because there isn't a saved active document for
+        # us to process. In that case, our current context is just fine. We
+        # are disabling state sending because the context change that might
+        # occur will try to trigger sending the state. Since we're definitely
+        # going to do exactly the same after this, we can just have it skip
+        # that part of the post context change routine.
+        with self.send_state_disabled():
+            try:
+                doc_path = self.adobe.app.activeDocument.fullName.fsName
+                if doc_path != self._ACTIVE_DOCUMENT_PATH:
+                    # This is admittedly questionable. Setting the current
+                    # is a public function, but we're jumping the gun here,
+                    # because this is typically set after the engine init
+                    # process is complete. We're not done, though, and we
+                    # have detected a situation where we need to change our
+                    # context to match that of the DCC's current document,
+                    # and so we need to make sure that Core knows that we
+                    # are the current engine.
+                    sgtk.platform.engine.set_current_engine(self)
+                    self._handle_active_document_change(doc_path)
+            except RuntimeError:
+                pass
 
         # now that qt is setup and the engine is ready to go, forward the
         # current state back to the adobe side.
@@ -345,6 +371,7 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
 
             if active_document_path:
                 self.logger.debug("New active document is %s" % active_document_path)
+                self._ACTIVE_DOCUMENT_PATH = active_document_path
             else:
                 self.logger.debug(
                     "New active document check failed. This is likely due to the "
@@ -560,6 +587,18 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
 
         self._HEARTBEAT_DISABLED = False
         self.logger.debug("Heartbeat restarted.")
+
+    @contextmanager
+    def send_state_disabled(self):
+        """
+        A context manager that disables the ability to send state to the
+        remote server. This is useful if you're forcing a context change
+        but know that you're going to be sending the state yourself later
+        on.
+        """
+        self._SEND_STATE_DISABLED = True
+        yield
+        self._SEND_STATE_DISABLED = False
 
     ############################################################################
     # UI
@@ -874,6 +913,9 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
         """
         Sends information back to javascript representing the current context.
         """
+        if self._SEND_STATE_DISABLED:
+            self.logger.debug("State sending has been disabled. Not sending.")
+            return
 
         # alert js that the state is about to change. this allows the panel to
         # clear its current state and display a loading message.


### PR DESCRIPTION
We attempt to interpret the current active document on engine init. If it corresponds to a different context than the one we're initializing with, we change context prior to sending state to the extension.