### PR TITLE
#40651: Refactors context caching.

### DIFF
--- a/python/tk_photoshopcc/shotgunutils.py
+++ b/python/tk_photoshopcc/shotgunutils.py
@@ -19,3 +19,8 @@ shotgun_globals = sgtk.platform.import_framework(
     "tk-framework-shotgunutils",
     "shotgun_globals"
 )
+
+settings = sgtk.platform.import_framework(
+    "tk-framework-shotgunutils",
+    "settings",
+)


### PR DESCRIPTION
Caching occurs both in memory and as a user setting at the project level. I would have loved to have stored the cache in Photoshop's DOM somehow, but that's not possible, as it appears as though CEP extensions work in a sandbox of sorts. That means that when the extension is restarted, any variables set in ExtendScript are not preserved. As such, we need to store the cache outside of Photoshop and the SGTK Python subprocess.