### PR TITLE
Don't use super for logging.StreamHandler since it is not new-style class in python 2.6

### DIFF
--- a/plugins/basic/python/tk_photoshopcc_basic/log.py
+++ b/plugins/basic/python/tk_photoshopcc_basic/log.py
@@ -22,7 +22,10 @@ class BootstrapLogHandler(logging.StreamHandler):
 
         :param record: The record to log.
         """
-        super(BootstrapLogHandler, self).emit(record)
+
+        # can't use super here because in python 2.6, logging.StreamHandler is
+        # not a new style class.
+        BootstrapLogHandler.emit(self, record)
 
         # always flush to ensure its seen by the js process
         self.flush()


### PR DESCRIPTION
Just a one line change to call the method on the base class instead of using `super`.