### PR TITLE
For #45220: Tweaks support for non-ascii document names.

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_document.py
+++ b/hooks/tk-multi-publish2/basic/publish_document.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+import sys
 import sgtk
 
 HookBaseClass = sgtk.get_hook_baseclass()
@@ -390,5 +391,16 @@ def _document_path(document):
         path = document.fullName.fsName
     except Exception:
         path = None
+
+    # The RPC API is always going to return a utf-8 encoded string
+    # here. This is fine (and correct) in almost all cases, but there
+    # are some situations on Windows where the encoded path, if it
+    # includes non-ascii characters, will test as false when checking
+    # existence. In that case, we're forced to decode the string to
+    # unicode.
+    #
+    # Note: This does not appear to be an issue on OS X.
+    if path and sys.platform.startswith("win") and not os.path.exists(path):
+        path = path.decode("utf-8")
 
     return path

--- a/python/tk_photoshopcc/adobe_bridge.py
+++ b/python/tk_photoshopcc/adobe_bridge.py
@@ -207,9 +207,6 @@ class AdobeBridge(Communicator):
             except Exception:
                 path = None
 
-            if isinstance(path, unicode):
-                path = path.encode("utf-8")
-
         return path
 
     def log_message(self, level, msg):

--- a/python/tk_photoshopcc/adobe_bridge.py
+++ b/python/tk_photoshopcc/adobe_bridge.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
+import sys
 import functools
 import threading
 
@@ -206,6 +207,17 @@ class AdobeBridge(Communicator):
                 path = doc.fullName.fsName
             except Exception:
                 path = None
+
+        # The RPC API is always going to return a utf-8 encoded string
+        # here. This is fine (and correct) in almost all cases, but there
+        # are some situations on Windows where the encoded path, if it
+        # includes non-ascii characters, will test as false when checking
+        # existence. In that case, we're forced to decode the string to
+        # unicode.
+        #
+        # Note: This does not appear to be an issue on OS X.
+        if path and sys.platform.startswith("win") and not os.path.exists(path):
+            path = path.decode("utf-8")
 
         return path
 


### PR DESCRIPTION
This attempts to resolve issues with publishing documents with paths that include non-ascii characters. The situation is different on Windows compared to OS X, so there is a small amount of OS-specific logic going on in one publish plugin, and in the adobe bridge.

In general, we return utf-8 strings, but there is now one situation on Windows where we're forced to decode to unicode before returning the document path.