### PR TITLE
#42805 Created thumbnail for photoshop documents that are not supported by Qt

### DIFF
--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -204,18 +204,24 @@ class PhotoshopCCSceneCollector(HookBaseClass):
                 # remember current document
                 current_document_cache = engine.adobe.get_active_document()
                 engine.adobe.app.activeDocument = document
-                # craete a temporary file to save document as .jpg
+
+                # create a temporary file to save document as .jpg
                 pathTemp = tempfile.NamedTemporaryFile(
                            suffix=".jpg",
                            prefix="sgtk_thumb_temp",
-                           delete=True
+                           delete=False
                            ).name
+
                 # save photoshop document as jpg (jpeg is supported by QPixmap).
                 # the "as copy" flag is set to true so that the temporary file won't
                 # be considererd officially as the saved version of the document to publish
                 # or to be edited by photoshop
                 document.saveAs(engine.adobe.File(pathTemp),engine.adobe.JPEGSaveOptions,True)
                 document_item.set_thumbnail_from_path(pathTemp)
+
+                # we do not need the temporary file anymore, so delete it
+                os.remove(pathTemp)
+
                 # restore active docuemnt
                 engine.adobe.app.activeDocument = current_document_cache
 

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -120,7 +120,9 @@ class PhotoshopCCSceneCollector(HookBaseClass):
             document_item.properties["document"] = document
 
             path = _document_path(document) 
-            if path: 
+            if path:
+                # try to set the thumbnail for display. won't display anything
+                # for psd/psb, but others should work.
                 document_item.set_thumbnail_from_path(path) 
 
             document_item.properties["work_template"] = work_template
@@ -173,6 +175,8 @@ class PhotoshopCCSceneCollector(HookBaseClass):
 
             path = _document_path(document) 
             if path: 
+                # try to set the thumbnail for display. won't display anything
+                # for psd/psb, but others should work.
                 document_item.set_thumbnail_from_path(path) 
 
             # store the template on the item for use by publish plugins. we


### PR DESCRIPTION
QPixmap does not support .psd. So in order to create a thumbnail, .psd file is saved as .jpg, then passed to QPixmap to create the thumbnail.