### PR TITLE
SG-6429 ensure the folder exists for the path before saving

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -557,8 +557,7 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
                 save_options = self.adobe.PhotoshopSaveOptions
 
             # Photoshop won't ensure that the folder is created when saving, so we must make sure it exists
-            folder = os.path.dirname(path)
-            ensure_folder_exists(folder)
+            ensure_folder_exists(os.path.dirname(path))
 
             document.saveAs(self.adobe.File(path), save_options)
 

--- a/engine.py
+++ b/engine.py
@@ -21,6 +21,7 @@ import re
 from contextlib import contextmanager
 
 import sgtk
+from sgtk.util.filesystem import ensure_folder_exists
 
 
 class PhotoshopCCEngine(sgtk.platform.Engine):
@@ -554,7 +555,11 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
             else:
                 # default value
                 save_options = self.adobe.PhotoshopSaveOptions
-           
+
+            # Photoshop won't ensure that the folder is created when saving, so we must make sure it exists
+            folder = os.path.dirname(path)
+            ensure_folder_exists(folder)
+
             document.saveAs(self.adobe.File(path), save_options)
 
             # restore the active document


### PR DESCRIPTION
This is actually a fix for an error that occurs during publishing, when trying to save the next version of the workfile.
If you have a version folder in your templates then when the publish code comes to save the next version of the workfile, it will fail, because the version folder hasn't been created yet. The fix ensures the folder is created before sending off the photoshop save command.

I've applied a similar fix to all the other engines, except in the other engines the fix has been in the publish hooks its self rather than the engine code. So I'm not sure if this is the right place?

This is the traceback of the error it is fixing:

```
Traceback (most recent call last): File "\\remmj06fbt9\G\ShotgunNiruhtam\mnt\software\7_2_2\install\app_store\tk-multi-publish2\v2.1.2\python\tk_multi_publish2\processing\plugin.py", line 393, in handle_plugin_error yield 
File "\\remmj06fbt9\G\ShotgunNiruhtam\mnt\software\7_2_2\install\app_store\tk-multi-publish2\v2.1.2\python\tk_multi_publish2\processing\plugin.py", line 375, in run_finalize self._hook_instance.finalize(settings, item) 
File "\\remmj06fbt9\G\ShotgunNiruhtam\mnt\software\7_2_2\install\app_store\tk-photoshopcc\v1.5.2\hooks\tk-multi-publish2\basic\publish_document.py", line 355, in finalize self._save_to_next_version(path, item, save_callback) 
File "\\remmj06fbt9\G\ShotgunNiruhtam\mnt\software\7_2_2\install\app_store\tk-multi-publish2\v2.1.2\hooks\publish_file.py", line 861, in _save_to_next_version save_callback(next_version_path) 
File "\\remmj06fbt9\G\ShotgunNiruhtam\mnt\software\7_2_2\install\app_store\tk-photoshopcc\v1.5.2\hooks\tk-multi-publish2\basic\publish_document.py", line 352, in save_callback = lambda path, d=document: engine.save_to_path(d, path) 
File "\\remmj06fbt9\G\ShotgunNiruhtam\mnt\software\7_2_2\install\app_store\tk-photoshopcc\v1.5.2\engine.py", line 558, in save_to_path document.saveAs(self.adobe.File(path), save_options) 
File "\\remmj06fbt9\G\ShotgunNiruhtam\mnt\software\7_2_2\install\app_store\tk-photoshopcc\v1.5.2\python\tk_photoshopcc\rpc\proxy.py", line 182, in __call_ parent=self._parent, 
File "\\remmj06fbt9\G\ShotgunNiruhtam\mnt\software\7_2_2\install\app_store\tk-photoshopcc\v1.5.2\python\tk_photoshopcc\rpc\communicator.py", line 283, in rpc_call raise RuntimeError(msg)RuntimeError: Failed to call method bound to with arguments [, ]
```