### PR TITLE
For SG-2596: Fixes window parenting on Windows when running in a PySide2 environment.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1074,6 +1074,7 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
                     proxy_win_hwnd_found = self.__tk_photoshopcc.win_32_api.find_windows(
                         stop_if_found=True,
                         class_name="Qt5QWindowIcon",
+                        process_id=os.getpid(),
                     )
                 finally:
                     win32_proxy_win.hide()

--- a/engine.py
+++ b/engine.py
@@ -1058,20 +1058,6 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
                 proxy_win_hwnd = self.__tk_photoshopcc.win_32_api.qwidget_winid_to_hwnd(
                     win32_proxy_win.winId(),
                 )
-
-                # Set the window style/flags. We don't need or want our Python
-                # dialogs to notify the Photoshop application window when they're
-                # opened or closed, so we'll disable that behavior.
-                win_ex_style = self.__tk_photoshopcc.win_32_api.GetWindowLong(
-                    proxy_win_hwnd,
-                    self.__tk_photoshopcc.win_32_api.GWL_EXSTYLE,
-                )
-
-                self.__tk_photoshopcc.win_32_api.SetWindowLong(
-                    proxy_win_hwnd,
-                    self.__tk_photoshopcc.win_32_api.GWL_EXSTYLE, 
-                    win_ex_style | self.__tk_photoshopcc.win_32_api.WS_EX_NOPARENTNOTIFY,
-                )
             else:
                 # With PySide2, we're required to look up our proxy parent
                 # widget's HWND the hard way, following the same logic used
@@ -1098,6 +1084,19 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
 
         # Parent to the Photoshop application window.
         if proxy_win_hwnd is not None:
+            # Set the window style/flags. We don't need or want our Python
+            # dialogs to notify the Photoshop application window when they're
+            # opened or closed, so we'll disable that behavior.
+            win_ex_style = self.__tk_photoshopcc.win_32_api.GetWindowLong(
+                proxy_win_hwnd,
+                self.__tk_photoshopcc.win_32_api.GWL_EXSTYLE,
+            )
+
+            self.__tk_photoshopcc.win_32_api.SetWindowLong(
+                proxy_win_hwnd,
+                self.__tk_photoshopcc.win_32_api.GWL_EXSTYLE, 
+                win_ex_style | self.__tk_photoshopcc.win_32_api.WS_EX_NOPARENTNOTIFY,
+            )
             self.__tk_photoshopcc.win_32_api.SetParent(proxy_win_hwnd, ps_hwnd)
             self._PROXY_WIN_HWND = proxy_win_hwnd
 

--- a/engine.py
+++ b/engine.py
@@ -1048,7 +1048,7 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
 
             # Create the proxy QWidget.
             win32_proxy_win = QtGui.QWidget()
-            window_title = "Shotgun Toolkit"
+            window_title = "Shotgun Toolkit Parent Widget"
             win32_proxy_win.setWindowTitle(window_title)
 
             # We have to take different approaches depending on whether
@@ -1080,6 +1080,11 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
 
                 if proxy_win_hwnd_found:
                     proxy_win_hwnd = proxy_win_hwnd_found[0]
+        else:
+            self.logger.debug(
+                "Unable to determine the HWND of Photoshop itself. This means "
+                "that we can't properly setup window parenting for Toolkit apps."
+            )
 
         # Parent to the Photoshop application window if we found everything
         # we needed. If we didn't find our proxy window for some reason, we

--- a/engine.py
+++ b/engine.py
@@ -1069,12 +1069,11 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
                 # hiding it.
                 win32_proxy_win.setGeometry(0, 0, 0, 0)
                 win32_proxy_win.show()
-                QtGui.QApplication.processEvents()
 
                 try:
                     proxy_win_hwnd_found = self.__tk_photoshopcc.win_32_api.find_windows(
                         stop_if_found=True,
-                        window_text=window_title,
+                        class_name="Qt5QWindowIcon",
                     )
                 finally:
                     win32_proxy_win.hide()

--- a/engine.py
+++ b/engine.py
@@ -1041,6 +1041,7 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
         # Get the main Photoshop window:
         ps_hwnd = self._win32_get_photoshop_main_hwnd()
         win32_proxy_win = None
+        proxy_win_hwnd = None
 
         if ps_hwnd:
             from tank.platform.qt import QtGui, QtCore
@@ -1079,8 +1080,6 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
 
                 if proxy_win_hwnd_found:
                     proxy_win_hwnd = proxy_win_hwnd_found[0]
-                else:
-                    proxy_win_hwnd
 
         # Parent to the Photoshop application window.
         if proxy_win_hwnd is not None:

--- a/engine.py
+++ b/engine.py
@@ -1069,6 +1069,7 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
                 # hiding it.
                 win32_proxy_win.setGeometry(0, 0, 0, 0)
                 win32_proxy_win.show()
+                QtGui.QApplication.processEvents()
 
                 try:
                     proxy_win_hwnd_found = self.__tk_photoshopcc.win_32_api.find_windows(


### PR DESCRIPTION
If the Photoshop CC integration makes use of a Python that has PySide2 (Qt5) installed, there are some additional considerations to be made on Windows concerning window parenting for Toolkit apps. Qt5's `QWidget.winId()` method does not return a Windows HWND the way that it did in Qt4. Instead, it returns an id number unique to Qt (WId). In C++, this WId type can be cast as an HWND, but that functionality is not exposed via PySide2.

The solution is to get the HWND for our proxy parent widget without using Qt to do so. We now use the same logic that's utilized to find Photoshop's window to look up the HWND of our proxy parent.