### PR TITLE
SG-14250: Ensures multiple sgtk dialogs do not get collapsed into a tabbed window on OSX

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1216,6 +1216,13 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
         # make sure the window raised so it doesn't
         # appear behind the main Photoshop window
         self.logger.debug("Showing dialog: %s" % (title,))
+
+        # Adding this window flag will ensure that our dialogs won't be
+        # tabbed together into a single window on OSX.
+        if sys.platform == "darwin":
+            from sgtk.platform.qt import QtCore
+            dialog.setWindowFlags(dialog.windowFlags() | QtCore.Qt.CustomizeWindowHint)
+
         dialog.show()
         dialog.raise_()
         dialog.activateWindow()


### PR DESCRIPTION
As in the subject. Adding the one window flag in this change will ensure that sgtk apps launch in their own windows in Photoshop.