### PR TITLE
SG-8610 Adds support for launching photoshop and opening a file

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -248,6 +248,17 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
                 dict(),
             )
 
+        # Normally the bootstrap logic would handle the file open, but since the bootstrap logic is handled by
+        # the adobe framework, and is generic, we should handle it here.
+        file_to_open = os.environ.get("SGTK_FILE_TO_OPEN")
+
+        if file_to_open:
+            # open the specified script
+            self.adobe.app.load(self.adobe.File(file_to_open))
+            # clear the environment variable after loading so that it doesn't get reopened on an engine restart.
+            del os.environ["SGTK_FILE_TO_OPEN"]
+
+
     def destroy_engine(self):
         """
         Called when the engine should tear down itself and all its apps.

--- a/startup.py
+++ b/startup.py
@@ -63,7 +63,6 @@ class PhotoshopLauncher(SoftwareLauncher):
         :param str file_to_open: (optional) Full path name of a file to open on launch.
         :returns: :class:`LaunchInformation` instance
         """
-        # todo - add support for the file_to_open parameter.
 
         # find the bootstrap script and import it.
         # note: all the business logic for how to launch is
@@ -79,6 +78,10 @@ class PhotoshopLauncher(SoftwareLauncher):
         # Add std context and site info to the env
         std_env = self.get_standard_plugin_environment()
         required_env.update(std_env)
+
+        # populate the file to open env.
+        if file_to_open:
+            required_env["SGTK_FILE_TO_OPEN"] = file_to_open
 
         return LaunchInformation(exec_path, args, required_env)
 


### PR DESCRIPTION
This adds functionality to enable the Photoshop engine to accept a file on start up and open it once Photoshop is launched.

Associated with [this PR](https://github.com/shotgunsoftware/tk-shotgun-launchpublish/pull/7).

Since the bootstrap logic is generic (via the adobe framework) I opted to put the open logic inside the engine post init method. Not sure if there is a more appropriate place to do this instead?

Similar to:
https://github.com/shotgunsoftware/tk-aftereffects/pull/29