### PR TITLE
SG-15054 Fixes launching with a file on Windows.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -248,17 +248,6 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
                 dict(),
             )
 
-        # Normally the bootstrap logic would handle the file open, but since the bootstrap logic is handled by
-        # the adobe framework, and is generic, we should handle it here.
-        file_to_open = os.environ.get("SGTK_FILE_TO_OPEN")
-
-        if file_to_open:
-            # open the specified script
-            self.adobe.app.load(self.adobe.File(file_to_open))
-            # clear the environment variable after loading so that it doesn't get reopened on an engine restart.
-            del os.environ["SGTK_FILE_TO_OPEN"]
-
-
     def destroy_engine(self):
         """
         Called when the engine should tear down itself and all its apps.

--- a/startup.py
+++ b/startup.py
@@ -92,9 +92,11 @@ class PhotoshopLauncher(SoftwareLauncher):
         std_env = self.get_standard_plugin_environment()
         required_env.update(std_env)
 
-        # populate the file to open env.
         if file_to_open:
-            required_env["SGTK_FILE_TO_OPEN"] = file_to_open
+            # If we have a file to open, add it to the end of the args so Photoshop opens the file.
+            # By providing the file as an arg, this will ensure that on Windows, Photoshop will open the file
+            # in a pre-existing Photoshop session if one is found.
+            args = " ".join([args, file_to_open])
 
         return LaunchInformation(exec_path, args, required_env)
 


### PR DESCRIPTION
Previously it would launch Photoshop and open the file if provided, but only if Photoshop wasn't already open.

By providing the file path to the executable rather than relying on the bootstrap code to open the file, Photoshop takes care of opening the file in the existing session.
This method means that the context doesn't get passed through to the engine if Photoshop is already started, but it will still try to automatically figure out the context based on the path, so it should be good enough, though I fear the Task might drop off in some cases.

It also means that if the user had already launched Photoshop without the Shotgun integration starting then, it will open the file but not start the integration.

So there are still some flaws but I figure this better than not having it.