### PR TITLE
SG-15580 Fixes an issue where Shotgun Create could not be launched

### DIFF
--- a/python/startup/bootstrap.py
+++ b/python/startup/bootstrap.py
@@ -72,17 +72,6 @@ def compute_environment():
     env["SHOTGUN_ADOBE_PYTHON"] = sys.executable
     env["SHOTGUN_ADOBE_FRAMEWORK_LOCATION"] = framework_location
     env["SHOTGUN_ENGINE"] = "tk-photoshopcc"
-
-    # We're going to append all of this Python process's sys.path to the
-    # PYTHONPATH environment variable. This will ensure that we have access
-    # to all libraries available in this process in subprocesses like the
-    # Python process that is spawned by the Shotgun CEP extension on launch
-    # of an Adobe host application. We're appending instead of setting because
-    # we don't want to stomp on any PYTHONPATH that might already exist that
-    # we want to persist when the Python subprocess is spawned.
-    sgtk.util.append_path_to_env_var(
-        "PYTHONPATH", os.pathsep.join(sys.path),
-    )
     env["PYTHONPATH"] = os.environ["PYTHONPATH"]
 
     return env


### PR DESCRIPTION
Create could not be launching from within Photoshop due to the inclusion of the Python interpreter paths in the `PYTHONPATH` env var. 
Removing this from the engine appears to have no negative impact, and is a cleaner fix than trying to tidy up the `PYTHONPATH` to pass onto Create or remove exclude it entirely.

The Python interpreter paths can still be found in the `sys.path` inside the launched Photoshop python interpreter instance, so I don't believe there would be any issues with importing anything.