### PR TITLE
Photoshop 24.1.0 save fix

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -473,19 +473,20 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
         """
         Save the document in place
         """
+        # since Photoshop 24.1.0, saving an already saved file triggers errors
+        if not document.saved:
+            with self.context_changes_disabled():
 
-        with self.context_changes_disabled():
+                # remember the active document so that we can restore it.
+                previous_active_document = self.adobe.app.activeDocument
 
-            # remember the active document so that we can restore it.
-            previous_active_document = self.adobe.app.activeDocument
+                # make the document being processed the active document
+                self.adobe.app.activeDocument = document
 
-            # make the document being processed the active document
-            self.adobe.app.activeDocument = document
+                document.save()
 
-            document.save()
-
-            # restore the active document
-            self.adobe.app.activeDocument = previous_active_document
+                # restore the active document
+                self.adobe.app.activeDocument = previous_active_document
 
     def save_to_path(self, document, path):
         """


### PR DESCRIPTION
photoshop version 24.1.0 causes error pop up when saving an already saved file, breaking the publish

it seems they changed the extendscript behaviour ... a simple check if it is already saved on engine level, should work. On our projects, we modified the hook in same way and it solved the issue.