### PR TITLE
SG-30404 Let publish_data come through as lists

### DIFF
--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -242,7 +242,10 @@ class PhotoshopUploadVersionPlugin(HookBaseClass):
 
         # if the file was published, add the publish data to the version
         if publish_data:
-            version_data["published_files"] = [publish_data]
+            # do not change the type of publish_data when it already is a list
+            if not isinstance(publish_data, list):
+                publish_data = [publish_data]
+            version_data["published_files"] = publish_data
 
         # log the version data for debugging
         self.logger.debug(


### PR DESCRIPTION
Versions can be linked to multiple published_files and so publish_data might already be a list. In that case we should avoid re putting that into a list to avoid errors when creating the version