### PR TITLE
SG-35979 context cache

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -802,7 +802,7 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
                         active_document_path,
                         previous_context=self.context,
                     )
-                    self.__add_to_context_cache(active_document_path, context)
+                    self.add_to_context_cache(active_document_path, context)
                 except Exception:
                     self.logger.debug(
                         "Unable to determine context from path. Setting the Project context."
@@ -1575,20 +1575,10 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
             if exit_code != 0:
                 self.logger.error("Failed to launch '%s'!" % cmd)
 
-    def add_to_context_cache(self, path, context):
-        """
-        This method acts as a wrapper around the protected
-        '__add_to_context_cache()' method.
-
-        :param str path: The document path to add to the cache.
-        :param context: The context object to associate with the document.
-        """
-        self.__add_to_context_cache(path, context)
-
     ##########################################################################################
     # context data methods
 
-    def __add_to_context_cache(self, path, context):
+    def add_to_context_cache(self, path, context):
         """
         Adds the given active document path to the context cache, associating
         it with the given context object. This will trigger the storing of a

--- a/engine.py
+++ b/engine.py
@@ -1575,7 +1575,7 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
             if exit_code != 0:
                 self.logger.error("Failed to launch '%s'!" % cmd)
 
-    def _add_to_context_cache(self, path, context):
+    def add_to_context_cache(self, path, context):
         """
         This method acts as a wrapper around the protected
         '__add_to_context_cache()' method.

--- a/engine.py
+++ b/engine.py
@@ -1575,6 +1575,16 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
             if exit_code != 0:
                 self.logger.error("Failed to launch '%s'!" % cmd)
 
+    def _add_to_context_cache(self, path, context):
+        """
+        This method acts as a wrapper around the protected
+        '__add_to_context_cache()' method.
+
+        :param str path: The document path to add to the cache.
+        :param context: The context object to associate with the document.
+        """
+        self.__add_to_context_cache(path, context)
+
     ##########################################################################################
     # context data methods
 

--- a/hooks/tk-multi-publish2/basic/publish_document.py
+++ b/hooks/tk-multi-publish2/basic/publish_document.py
@@ -349,8 +349,8 @@ class PhotoshopCCDocumentPublishPlugin(HookBaseClass):
         # bump the document path to the next version
         new_version_path = self._save_to_next_version(path, item, save_callback)
 
-        if hasattr(self.parent.engine, "add_to_context_cache"):
-            self.parent.engine.add_to_context_cache(new_version_path, item.context)
+        if hasattr(engine, "add_to_context_cache"):
+            engine.add_to_context_cache(new_version_path, item.context)
 
 
 def _get_save_as_action(document):

--- a/hooks/tk-multi-publish2/basic/publish_document.py
+++ b/hooks/tk-multi-publish2/basic/publish_document.py
@@ -347,7 +347,10 @@ class PhotoshopCCDocumentPublishPlugin(HookBaseClass):
         save_callback = lambda path, d=document: engine.save_to_path(d, path)
 
         # bump the document path to the next version
-        self._save_to_next_version(path, item, save_callback)
+        new_version_path = self._save_to_next_version(path, item, save_callback)
+
+        if hasattr(self.parent.engine, "add_to_context_cache"):
+            self.parent.engine.add_to_context_cache(new_version_path, item.context)
 
 
 def _get_save_as_action(document):


### PR DESCRIPTION
_add_to_context_cache method acts as a wrapper around the protected '__add_to_context_cache()' method.
This method is used [here](https://github.com/shotgunsoftware/tk-multi-workfiles2/pull/152/files) 