### PR TITLE
SG-38382 Quickfix for RuntimeError: Internal C++ object (TankQDialog) already deleted.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1807,6 +1807,22 @@ class PhotoshopCCEngine(sgtk.platform.Engine):
         elif sys.platform == "win32":
             pass
 
+    def _on_dialog_closed(self, dlg):
+        """
+        Called when a dialog created by this engine is closed.
+
+        :param dlg: The dialog being closed
+        :type dlg: :class:`PySide.QtGui.QWidget`
+
+        Derived implementations of this method should be sure to call
+        the base implementation
+        """
+        super()._on_dialog_closed(dlg)
+        # workaround fix that solves the obsolete pointer issue
+        # which produces a pointer pointing to a wrapped C++ object, that was
+        # already deleted by garbage collection ... I assume
+        self._DIALOG_PARENT = None
+
 
 # a little action script to activate the given python process.
 OSX_ACTIVATE_SCRIPT = """


### PR DESCRIPTION
As we were upgrading our fork of the configuration and other repos to finally. be able to move to Desktop 2.0.0 from 1.9.2, we noticed a weird bug introduced on a very low level.

Because both the app dialogs as well as the busy splash screen use the same parent dialog, there seems to happen a weird interaction ob clear busy, which affects the engine's _DIALOG_PARENT to be collected by garbage collector but still storing it as a valid pointer: e.g. `self._DIALOG_PARENT is None` returns False, while trying to execute its methos or print it causes this error log to appear

```
Querying related tasks for context: Exit Game, Asset Popups
Detected std style sheet file '/Users/samy.benrabah/Library/Caches/Shotgun/bundle_cache/app_store/tk-multi-publish2/v2.10.1/style.qss' - applying to widget <tank.platform.qt.tankqdialog.__AppDialog_TkWidgetWrapper__(0x600001e094a0, name="Dialog") at 0x124cf9980>
Traceback (most recent call last):
  File "/Users/samy.benrabah/Library/Caches/Shotgun/bundle_cache/app_store/tk-photoshopcc/v1.11.5/engine.py", line 863, in _handle_command
    result = command["callback"]()
  File "/Users/samy.benrabah/Library/Caches/Shotgun/outfit7/p2861c8317.basic.adobe/cfg/install/core/python/tank/platform/engine.py", line 1091, in callback_wrapper
    return callback(*args, **kwargs)
  File "/Users/samy.benrabah/Library/Caches/Shotgun/bundle_cache/app_store/tk-multi-publish2/v2.10.1/app.py", line 55, in <lambda>
    cb = lambda: tk_multi_publish2.show_dialog(self)
  File "/Users/samy.benrabah/Library/Caches/Shotgun/bundle_cache/app_store/tk-multi-publish2/v2.10.1/python/tk_multi_publish2/__init__.py", line 35, in show_dialog
    app.engine.show_dialog(display_name, app, AppDialog)
  File "/Users/samy.benrabah/Library/Caches/Shotgun/bundle_cache/app_store/tk-photoshopcc/v1.11.5/engine.py", line 1227, in show_dialog
    dialog, widget = self._create_dialog_with_widget(
  File "/Users/samy.benrabah/Library/Caches/Shotgun/outfit7/p2861c8317.basic.adobe/cfg/install/core/python/tank/platform/engine.py", line 1762, in _create_dialog_with_widget
    dialog = self._create_dialog(title, bundle, widget, parent)
  File "/Users/samy.benrabah/Library/Caches/Shotgun/outfit7/p2861c8317.basic.adobe/cfg/install/core/python/tank/platform/engine.py", line 1657, in _create_dialog
    dialog = tankqdialog.TankQDialog(title, bundle, widget, parent)
  File "/Users/samy.benrabah/Library/Caches/Shotgun/outfit7/p2861c8317.basic.adobe/cfg/install/core/python/tank/platform/qt/tankqdialog.py", line 189, in __init__
    TankDialogBase.__init__(self, parent)
RuntimeError: Internal C++ object (TankQDialog) already deleted.
Completed query for the current user's Tasks.
```

To reproduce the issue (in our case on Desktop 1.9.2) same as in video:

1. Open Photoshop integration and in it the PTR Python console
2. Do a `engine.show_busy("TEST", "TEST")` ... you can also clear it (but that is done on the engine level alredy when handling dialog closure)
3. Try open any app that creates a dialog ... once the loading bar in plugin is no more, nothing will open and the same log should appear in photoshop logs (unless it is caught in the race condition with a environment not set on background tasks ... that is another PR to be opened on tk-core)


https://github.com/user-attachments/assets/f0a27124-7aa6-4a02-87a6-d89793b120d3

