### PR TITLE
SG-43666 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,6 @@ repos:
 
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black

--- a/hooks/tk-multi-publish2/basic/publish_image.py
+++ b/hooks/tk-multi-publish2/basic/publish_image.py
@@ -52,7 +52,7 @@ class PhotoshopCCImagePublishPlugin(HookBaseClass):
         part of its environment configuration.
         """
         # inherit the settings from the base publish plugin
-        base_settings = super(PhotoshopCCImagePublishPlugin, self).settings or {}
+        base_settings = super().settings or {}
 
         # settings specific to this class
         plugin_settings = {

--- a/info.yml
+++ b/info.yml
@@ -58,6 +58,7 @@ description: "Flow Production Tracking Integration for Photoshop"
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.19.18"
+minimum_python_version: "3.9"
 
 frameworks:
   - {"name": "tk-framework-shotgunutils", "version": "v5.x.x"}


### PR DESCRIPTION
## Summary

- Set `minimum_python_version: "3.9"` in `info.yml`
- Modernize old-style `super()` call in `publish_image.py`

## Test plan

- [ ] Engine loads correctly on Python 3.9+

🤖 Generated with [Claude Code](https://claude.com/claude-code)